### PR TITLE
[WIP] First pass at proxy endpoint for 1degree organization API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 # 1degree
+ONE_DEGREE_API_KEY=<ADD_API_KEY_HERE>
+ONE_DEGREE_API_URL=https://host.domain.tld
 ONE_DEGREE_AUTH_URL=http://host.domain.tld

--- a/api/Organizations.js
+++ b/api/Organizations.js
@@ -1,0 +1,24 @@
+import axios from 'axios';
+
+const Organizations = () => ({
+  search: async ({ page = 1, perPage = 10, queryText }) => {
+    return axios
+      .get(`${process.env.ONE_DEGREE_API_URL}/v1/organizations.json`, {
+        params: {
+          api_key: process.env.ONE_DEGREE_API_KEY,
+          locale: 'en',
+          page,
+          per_page: perPage,
+          'query[text]': queryText,
+        },
+      })
+      .then((response) => {
+        return response.data;
+      })
+      .catch((error) => {
+        return error;
+      });
+  },
+});
+
+export default Organizations;

--- a/nextjs-server.js
+++ b/nextjs-server.js
@@ -5,6 +5,7 @@ import bodyParser from 'body-parser';
 
 import routes from './routes';
 import Auth from './api/Auth';
+import Organizations from './api/Organizations';
 
 require('dotenv').config({ path: './.env' });
 
@@ -29,6 +30,20 @@ app.prepare().then(() => {
     const authAPI = new Auth();
     const response = await authAPI
       .login(req)
+      .then((result) => {
+        return result;
+      })
+      .catch((error) => {
+        return error;
+      });
+
+    res.end(JSON.stringify(response));
+  });
+
+  server.get('/organizations', async (req, res) => {
+    const orgsAPI = new Organizations();
+    const response = await orgsAPI
+      .search({ queryText: req.query.search, page: req.query.page })
       .then((result) => {
         return result;
       })


### PR DESCRIPTION
Leaving this as a draft since I'm pretty sure this is not this PR's final form.

This is a first attempt at issue #25, providing a proxy endpoint to the 1Degree Organization Search endpoint for the frontend to query against without exposing credentials to the client. I added a simple route (`/organizations`) which mimics the pattern of the Auth API that was already there to query the 1Degree API based on a query param named `search` (`/organizations?search=someOrgName`). Also supports a `page` query param to select the page of search results, and right now I set the default page size to 10.

This requires 2 more env variables, `ONE_DEGREE_API_KEY` (self explanatory) and `ONE_DEGREE_API_URL` which is the root of the API domain (`https://data.1degree.org`). That might not actually need to be an env var, maybe it should be hardcoded?

My biggest open question is if/how we want to filter or re-map the data coming back from the API, but I wasn't sure what to exclude/include based on the issue description alone. I'm sure there is more to add but I thought I'd get the ball rolling first.